### PR TITLE
Update CoreMLPythonUtils.mm

### DIFF
--- a/coremlpython/CoreMLPythonUtils.mm
+++ b/coremlpython/CoreMLPythonUtils.mm
@@ -326,7 +326,10 @@ static MLFeatureValue * convertValueToImage(const py::handle& handle) {
     status = CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
     handleCVReturn(status);
 
-    return [MLFeatureValue featureValueWithPixelBuffer:pixelBuffer];
+    MLFeatureValue *fv = [MLFeatureValue featureValueWithPixelBuffer:pixelBuffer];
+    CVPixelBufferRelease(pixelBuffer);
+    
+    return fv;
 }
 
 static bool IsPILImage(const py::handle& handle) {


### PR DESCRIPTION
CoreMLPythonUtils.mm:convertValueToImage leaks a CVPixelBuffer.
Add the missing CVPixelBufferRelease().